### PR TITLE
Remove stroke on table_rect

### DIFF
--- a/lttr.typ
+++ b/lttr.typ
@@ -339,6 +339,7 @@
                 let table_rect = rect(
                     outset: 0pt,
                     inset: 0pt,
+                    stroke: none,
                     tbl
                 )
                 let dy = lttr_max_dy.at(loc) + state.horizontal_table.spacing


### PR DESCRIPTION
Setting stroke to 'none' for the table_rect of horizontal_table, so it doesn't have a border when debug is 'false'.
For debug: true, the border will be provided by the if statement in the table command itself.